### PR TITLE
Minor correction to Vec2.rotate/2

### DIFF
--- a/lib/Vec2.ex
+++ b/lib/Vec2.ex
@@ -257,7 +257,7 @@ defmodule Graphmath.Vec2 do
         { x,y } = a
         ct = :math.cos(theta)
         st = :math.sin(theta)
-        { x*ct + y*st, x*st - y*ct }
+        { x*ct - y*st, x*st + y*ct }
     end
 
     @doc """

--- a/test/vec2/vec2_rotation_test.exs
+++ b/test/vec2/vec2_rotation_test.exs
@@ -34,4 +34,46 @@ defmodule Graphmath.Vec2.Rotate_Vec2 do
     {x,y} = Graphmath.Vec2.rotate( {1,0}, :math.pi)
     assert {-1,0} == { Float.round(x,6), Float.round(y,6)}
   end
+
+  @tag :vec2
+  @tag :rotate
+  test "rotate( {0,1}, :math.pi) returns {0,-1}" do
+    {x,y} = Graphmath.Vec2.rotate({0,1}, :math.pi)
+    assert {0,-1} == { Float.round(x,6), Float.round(y,6)}
+  end
+
+  @tag :vec2
+  @tag :rotate
+  test "rotate( {0,-1}, :math.pi) returns {0,1}" do
+    {x,y} = Graphmath.Vec2.rotate({0,-1}, :math.pi)
+    assert {0,1} == { Float.round(x,6), Float.round(y,6)}
+  end
+
+  @tag :vec2
+  @tag :rotate
+  test "rotate( {0,1}, :math.pi//2) returns {-1,0}" do
+    {x,y} = Graphmath.Vec2.rotate({0,1}, :math.pi/2)
+    assert {-1,0} == { Float.round(x,6), Float.round(y,6)}
+  end
+
+  @tag :vec2
+  @tag :rotate
+  test "rotate( {0,-1}, :math.pi//2) returns {1,0}" do
+    {x,y} = Graphmath.Vec2.rotate({0,-1}, :math.pi/2)
+    assert {1,0} == { Float.round(x,6), Float.round(y,6)}
+  end
+
+  @tag :vec2
+  @tag :rotate
+  test "rotate( {0,1}, -(:math.pi//2)) returns {1,0}" do
+    {x,y} = Graphmath.Vec2.rotate({0,1}, -:math.pi/2)
+    assert {1,0} == { Float.round(x,6), Float.round(y,6)}
+  end
+
+  @tag :vec2
+  @tag :rotate
+  test "rotate( {0,-1}, -(:math.pi//2)) returns {-1,0}" do
+    {x,y} = Graphmath.Vec2.rotate({0,-1}, -:math.pi/2)
+    assert {-1,0} == { Float.round(x,6), Float.round(y,6)}
+  end
 end


### PR DESCRIPTION
Used https://en.wikipedia.org/wiki/Rotation_matrix as my reference and
believe that the equation for CCW rotation is (x_ct - y_st, x_st + y_ct)
and corrected accordingly.

I noticed the issue when rotating (0, 1) by PI the previous
implementation would produce (0, 1) as the new vec, which is obviously
not correct.

I added six test cases for the y axis to confirm the following

rotate({0,1}, :math.pi) = {0,-1}
rotate({0,-1}, :math.pi) = {0,1}
rotate({0,1}, :math.pi/2) = {-1,0}
rotate({0,-1}, :math.pi/2) = {1,0}
rotate({0,1}, -:math.pi/2) = {1,0}
rotate({0,-1}, -:math.pi/2) = {-1,0}
